### PR TITLE
Adding script to automate capture of Odin Framework

### DIFF
--- a/.github/AUTOMATED_SCRIPTS.md
+++ b/.github/AUTOMATED_SCRIPTS.md
@@ -11,7 +11,7 @@ $ cd scripts/
 $ python get-odin.py 1.0.0 # example capture for version 1.0.0 
 ```
 ## Dependencies
-* [Python 3](https://www.python.org/download/releases/3.0/)
+* [Python 2](https://www.python.org/downloads/release/python-2715/)
 * [requests](http://docs.python-requests.org/en/master/)
 * [zipfile](https://docs.python.org/3/library/zipfile.html)
 * [shutil](https://docs.python.org/3/library/shutil.html)

--- a/.github/AUTOMATED_SCRIPTS.md
+++ b/.github/AUTOMATED_SCRIPTS.md
@@ -1,0 +1,24 @@
+# Automated Scripts :rocket:
+You can use a ready script written in `Python` to download any version of **Odin Framework** using the commands: 
+```shell
+$ cd scripts/
+$ python get-odin.py # capture the latest version
+```
+
+Or if you want to capture an old version: 
+```shell
+$ cd scripts/
+$ python get-odin.py 1.0.0 # example capture for version 1.0.0 
+```
+## Dependencies
+* [Python 3](https://www.python.org/download/releases/3.0/)
+* [requests](http://docs.python-requests.org/en/master/)
+* [zipfile](https://docs.python.org/3/library/zipfile.html)
+* [shutil](https://docs.python.org/3/library/shutil.html)
+
+## More informations
+You can get as many versions of the **Odin Framework** as you want :heavy_check_mark: \
+Only equal versions are not accepted :heavy_multiplication_x:
+
+After running the script... :running: \
+To check if everything went well, just open the folder `wp-contents/themes/odin/` and check if the version was added to the folder successfully, then just activate the theme with the added version :ballot_box_with_check:

--- a/.github/AUTOMATED_SCRIPTS.md
+++ b/.github/AUTOMATED_SCRIPTS.md
@@ -1,5 +1,5 @@
 # Automated Scripts :rocket:
-You can use a ready script written in `Python` to download any version of **Odin Framework** using the commands: 
+You can use a ready script :fire: written in `Python` to download any version of **Odin Framework** using the commands: 
 ```shell
 $ cd scripts/
 $ python get-odin.py # capture the latest version

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.scripts/.cache/

--- a/README.md
+++ b/README.md
@@ -45,5 +45,5 @@ In your browser you can use localhost to acess your wordpress and your theme.
 
 And Great Job !
 
-### Automated Scripts
-Click [here](.github/AUTOMATED_SCRIPTS.md) for more informations about automated scripts.
+### Automated Scripts :fire:
+Click [here](.github/AUTOMATED_SCRIPTS.md) for more informations about automated scripts :book:

--- a/README.md
+++ b/README.md
@@ -45,3 +45,5 @@ In your browser you can use localhost to acess your wordpress and your theme.
 
 And Great Job !
 
+### Automated Scripts
+Click [here](.github/AUTOMATED_SCRIPTS.md) for more informations about automated scripts.

--- a/scripts/get-odin.py
+++ b/scripts/get-odin.py
@@ -3,11 +3,12 @@ from requests import get
 from os import path, makedirs, listdir
 from zipfile import ZipFile
 from re import compile
-from shutil import move
+from shutil import move, rmtree
 
 FOLDER = ".cache/"
 FOLDER_THEMES_WORDPRESS_ODIN = "../wp-content/themes/odin/"
 NAME_FILE = "odin.zip"
+URL_ODIN_FRAMEWORK = "https://api.github.com/repos/wpbrasil/odin/zipball/"
 
 def __download_odin__(url):
   completed_download = False
@@ -24,7 +25,7 @@ def __download_odin__(url):
 
       completed_download = True
     except:
-      completed_download = False
+      print("error download odin, verify url or version")
 
 
   return completed_download
@@ -39,12 +40,13 @@ def __extract_odin__(file):
     archive.close()
     completed_extract = True
   except:
-    completed_extract = False
+    print("error extract odin, verify download successful")
 
   return completed_extract
 
 def __move_odin__(folder):
   completed_move = False
+  print("move folder odin for folder wordpress themes")
 
   regex_folder_odin = compile("wpbrasil-odin-*")
   folder_odin = filter(regex_folder_odin.match, listdir(folder))
@@ -54,13 +56,15 @@ def __move_odin__(folder):
       move(folder + folder_odin, FOLDER_THEMES_WORDPRESS_ODIN)
       completed_move = True
     except:
-      completed_move = False
+      print("error move odin, verify extract successful")
   
   return completed_move
 
 def __get_odin__(version):
   completed_get = False
-  url = "https://api.github.com/repos/wpbrasil/odin/zipball/" + version
+  url = URL_ODIN_FRAMEWORK + version
+  print("get odin framework")
+
   if(__download_odin__(url)):
     print("download done!")
     if(__extract_odin__(FOLDER + NAME_FILE)):
@@ -76,12 +80,28 @@ def __get_odin__(version):
     print("download fail!")
   return completed_get
 
+def __remove_cache__(folder):
+  completed_remove_cache = False
+  print("remove cache folder")
+
+  #try:
+  rmtree(folder)
+  completed_remove_cache = True
+  #except:
+  #  print("error remove cache folder, verify PATH folder cache")
+
+  return completed_remove_cache
+
 def __main__():
   version = ""
   if(len(argv) > 1):
     version = argv[1]
   if(__get_odin__(version)):
     print("get odin done!")
+    if(__remove_cache__(FOLDER)):
+      print("cache remove done!")
+    else:
+      print("error remove cache!")    
   else:
     print("error get odin!")
 

--- a/scripts/get-odin.py
+++ b/scripts/get-odin.py
@@ -11,6 +11,19 @@ NAME_FILE = "odin.zip"
 URL_ODIN_FRAMEWORK = "https://api.github.com/repos/wpbrasil/odin/zipball/"
 
 def __download_odin__(url):
+  """
+    Download the Odin Framework zip file and add it to the .cache/ folder.
+
+    Parameters
+    ----------
+    url : string
+      File URL to download.
+
+    Returns
+    -------
+    bool
+      Return True if you have successfully downloaded False and otherwise.
+  """
   completed_download = False
   if(url):
     print("download odin framework, url: {}".format(url))
@@ -31,6 +44,19 @@ def __download_odin__(url):
   return completed_download
 
 def __extract_odin__(file):
+  """
+    Extracting zip file in .cache/ folder.
+
+    Parameters
+    ----------
+    file : string
+      Path of the file to be extracted.
+
+    Returns
+    -------
+    bool
+      Return True if you have successfully extracted False and otherwise.
+  """
   completed_extract = False
   print("extract odin framework, file: {}".format(file))
   
@@ -45,6 +71,19 @@ def __extract_odin__(file):
   return completed_extract
 
 def __move_odin__(folder):
+  """
+    Move cache folder to the Odin themes folder of the wordpress container (wp-cotent/themes/odin/).
+
+    Parameters
+    ----------
+    folder : string
+      Path to container folder Odin themes.
+
+    Returns
+    -------
+    bool
+      Return True if you have successfully moved False and otherwise.
+  """
   completed_move = False
   print("move folder odin for folder wordpress themes")
 
@@ -61,6 +100,19 @@ def __move_odin__(folder):
   return completed_move
 
 def __get_odin__(version):
+  """
+    Capture the Odin of the official website and move to the wordpress container themes folder (wp-content/themes/odin/).
+
+    Parameters
+    ----------
+    version : string
+      Odin's version.
+
+    Returns
+    -------
+    bool
+      Return True if you have successfully get False and otherwise.
+  """
   completed_get = False
   url = URL_ODIN_FRAMEWORK + version
   print("get odin framework")
@@ -81,6 +133,18 @@ def __get_odin__(version):
   return completed_get
 
 def __remove_cache__(folder):
+  """
+    Remove folder used for caching.
+
+    Parameters
+    ----------
+    folder : string
+      Folder path to delete.
+    Returns
+    -------
+    bool
+      Return True if you have successfully removed False and otherwise.
+  """
   completed_remove_cache = False
   print("remove cache folder")
 

--- a/scripts/get-odin.py
+++ b/scripts/get-odin.py
@@ -5,10 +5,10 @@ from zipfile import ZipFile
 from re import compile
 from shutil import move, rmtree
 
-FOLDER = ".cache/"
-FOLDER_THEMES_WORDPRESS_ODIN = "../wp-content/themes/odin/"
-NAME_FILE = "odin.zip"
-URL_ODIN_FRAMEWORK = "https://api.github.com/repos/wpbrasil/odin/zipball/"
+FOLDER = ".cache/" # folder containing temporarily downloaded files.
+FOLDER_THEMES_WORDPRESS_ODIN = "../wp-content/themes/odin/" # path to Odio themes folder from WordPress container.
+NAME_FILE = "odin.zip" # name of the downloaded file .zip of the official website
+URL_ODIN_FRAMEWORK = "https://api.github.com/repos/wpbrasil/odin/zipball/" # URL of the official website framework.
 
 def __download_odin__(url):
   """

--- a/scripts/get-odin.py
+++ b/scripts/get-odin.py
@@ -84,11 +84,11 @@ def __remove_cache__(folder):
   completed_remove_cache = False
   print("remove cache folder")
 
-  #try:
-  rmtree(folder)
-  completed_remove_cache = True
-  #except:
-  #  print("error remove cache folder, verify PATH folder cache")
+  try:
+    rmtree(folder)
+    completed_remove_cache = True
+  except:
+    print("error remove cache folder, verify PATH folder cache")
 
   return completed_remove_cache
 

--- a/scripts/get-odin.py
+++ b/scripts/get-odin.py
@@ -1,0 +1,88 @@
+from sys import argv
+from requests import get
+from os import path, makedirs, listdir
+from zipfile import ZipFile
+from re import compile
+from shutil import move
+
+FOLDER = ".cache/"
+FOLDER_THEMES_WORDPRESS_ODIN = "../wp-content/themes/odin/"
+NAME_FILE = "odin.zip"
+
+def __download_odin__(url):
+  completed_download = False
+  if(url):
+    print("download odin framework, url: {}".format(url))
+    response = get(url)
+
+    if(not path.exists(FOLDER)):
+      makedirs(FOLDER)
+    
+    try:
+      with open(FOLDER + NAME_FILE, "wb") as code:
+        code.write(response.content)
+
+      completed_download = True
+    except:
+      completed_download = False
+
+
+  return completed_download
+
+def __extract_odin__(file):
+  completed_extract = False
+  print("extract odin framework, file: {}".format(file))
+  
+  try:
+    archive = ZipFile(file, "r")
+    archive.extractall(FOLDER)
+    archive.close()
+    completed_extract = True
+  except:
+    completed_extract = False
+
+  return completed_extract
+
+def __move_odin__(folder):
+  completed_move = False
+
+  regex_folder_odin = compile("wpbrasil-odin-*")
+  folder_odin = filter(regex_folder_odin.match, listdir(folder))
+  if(len(folder_odin) > 0):
+    folder_odin = folder_odin[0]
+    try:
+      move(folder + folder_odin, FOLDER_THEMES_WORDPRESS_ODIN)
+      completed_move = True
+    except:
+      completed_move = False
+  
+  return completed_move
+
+def __get_odin__(version):
+  completed_get = False
+  url = "https://api.github.com/repos/wpbrasil/odin/zipball/" + version
+  if(__download_odin__(url)):
+    print("download done!")
+    if(__extract_odin__(FOLDER + NAME_FILE)):
+      print("extract done!")
+      if(__move_odin__(FOLDER)):
+        print("move folder done!")
+        completed_get = True
+      else:
+        print("move folder fail!")
+    else:
+      print("extract fail!")
+  else:
+    print("download fail!")
+  return completed_get
+
+def __main__():
+  version = ""
+  if(len(argv) > 1):
+    version = argv[1]
+  if(__get_odin__(version)):
+    print("get odin done!")
+  else:
+    print("error get odin!")
+
+__main__()


### PR DESCRIPTION
**Summary**
Adding script to automate the capture of the Odin Framework with python and the librarian requests :fire:

**Context**
I noticed that to start a project it is necessary to manually download and extract in the `wp-content/themes/odin/` folder, I thought it would be interesting to automate this task, using python I got a script to capture any version of Odin Framework and already add in theme folders :smile: 

**More informations**
I just tested it on my machine, but if you find it interesting, send me some feedback :+1: 